### PR TITLE
Add support for referencing other variables in .env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ An example `.env` file would be:
 ```
 DB_HOST=test.com
 DB_PORT=1234
+DB_URL=postgresql://$DB_HOST:$DB_PORT
 IS_ENABLED=0
 ```
 


### PR DESCRIPTION
This PR adds support for referencing other variables in the `.env` file.

Please keep in mind I've just started playing with Swift and I bet it could be implemented in better way. I had problems with regex substring so please let me know if there are better ways to do it.